### PR TITLE
PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,38 +12,28 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.3
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#10](https://github.com/laminas/laminas-navigation/pull/10) Add PHP 8.0 support
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-stdlib": "^2.7 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
@@ -39,10 +39,11 @@
         "laminas/laminas-mvc": "^2.7.9 || ^3.0.4",
         "laminas/laminas-permissions-acl": "^2.6",
         "laminas/laminas-router": "^3.0.2",
-        "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+        "laminas/laminas-servicemanager": "^3.2.1",
         "laminas/laminas-uri": "^2.5.2",
         "laminas/laminas-view": "^2.9",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.4.1"
     },
     "suggest": {
         "laminas/laminas-config": "^2.6 || ^3.1, to provide page configuration (optional, as arrays and Traversables are also allowed)",

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -20,22 +20,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ContainerTest extends TestCase
 {
-    /**
-     * Prepares the environment before running a test.
-     *
-     */
-    protected function setUp()
-    {
-    }
-
-    /**
-     * Tear down the environment after running a test
-     *
-     */
-    protected function tearDown()
-    {
-    }
-
     public function testConstructWithArray()
     {
         $argument = [
@@ -86,7 +70,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $pages', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $pages', $e->getMessage());
         }
 
         try {
@@ -95,7 +79,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $pages', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $pages', $e->getMessage());
         }
 
         try {
@@ -104,7 +88,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\ExceptionInterface $e) {
-            $this->assertContains('Invalid argument: $pages', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $pages', $e->getMessage());
         }
     }
 
@@ -546,7 +530,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $pages must be', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $pages must be', $e->getMessage());
         }
     }
 
@@ -560,7 +544,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $pages must be', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $pages must be', $e->getMessage());
         }
     }
 
@@ -1087,7 +1071,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\BadMethodCallException $e) {
-            $this->assertContains('Bad method call', $e->getMessage());
+            $this->assertStringContainsString('Bad method call', $e->getMessage());
         }
     }
 
@@ -1101,7 +1085,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\BadMethodCallException $e) {
-            $this->assertContains('Bad method call', $e->getMessage());
+            $this->assertStringContainsString('Bad method call', $e->getMessage());
         }
     }
 
@@ -1196,7 +1180,7 @@ class ContainerTest extends TestCase
                         'but a Laminas\Navigation\Exception\InvalidArgumentException was ' .
                         'not thrown');
         } catch (Navigation\Exception\OutOfBoundsException $e) {
-            $this->assertContains('Corruption detected', $e->getMessage());
+            $this->assertStringContainsString('Corruption detected', $e->getMessage());
         }
     }
 

--- a/test/NavigationTest.php
+++ b/test/NavigationTest.php
@@ -27,13 +27,13 @@ class NavigationTest extends TestCase
     private $_navigation;
     // @codingStandardsIgnoreEnd
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_navigation = new \Laminas\Navigation\Navigation();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->_navigation = null;
         parent::tearDown();

--- a/test/Page/MvcTest.php
+++ b/test/Page/MvcTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MvcTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $routeClass = $this->getRouteClass();
         $this->route  = new $routeClass(

--- a/test/Page/PageFactoryTest.php
+++ b/test/Page/PageFactoryTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Navigation\Page;
 
 use Laminas\Navigation;
+use Laminas\Navigation\Exception\InvalidArgumentException;
 use Laminas\Navigation\Page\AbstractPage;
 use PHPUnit\Framework\TestCase;
 
@@ -152,11 +153,10 @@ class PageFactoryTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Laminas\Navigation\Exception\InvalidArgumentException
-     */
     public function testShouldThrowExceptionOnInvalidMethodArgument()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         AbstractPage::factory('');
     }
 }

--- a/test/Page/PageTest.php
+++ b/test/Page/PageTest.php
@@ -24,23 +24,6 @@ use PHPUnit\Framework\TestCase;
  */
 class PageTest extends TestCase
 {
-    /**
-     * Prepares the environment before running a test.
-     *
-     */
-    protected function setUp()
-    {
-    }
-
-    /**
-     * Tear down the environment after running a test
-     *
-     */
-    protected function tearDown()
-    {
-        // setConfig, setOptions
-    }
-
     public function testSetShouldMapToNativeProperties()
     {
         $page = AbstractPage::factory([
@@ -163,7 +146,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains('Invalid argument: $label', $e->getMessage());
+                $this->assertStringContainsString('Invalid argument: $label', $e->getMessage());
             }
         }
     }
@@ -190,7 +173,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                             'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains(
+                $this->assertStringContainsString(
                     'Invalid argument: $fragment',
                     $e->getMessage()
                 );
@@ -217,7 +200,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains('Invalid argument: $id', $e->getMessage());
+                $this->assertStringContainsString('Invalid argument: $id', $e->getMessage());
             }
         }
     }
@@ -251,7 +234,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains('Invalid argument: $class', $e->getMessage());
+                $this->assertStringContainsString('Invalid argument: $class', $e->getMessage());
             }
         }
     }
@@ -274,7 +257,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains('Invalid argument: $title', $e->getMessage());
+                $this->assertStringContainsString('Invalid argument: $title', $e->getMessage());
             }
         }
     }
@@ -297,7 +280,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains('Invalid argument: $target', $e->getMessage());
+                $this->assertStringContainsString('Invalid argument: $target', $e->getMessage());
             }
         }
     }
@@ -428,7 +411,7 @@ class PageTest extends TestCase
                 $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
             } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertContains('Invalid argument: $order', $e->getMessage());
+                $this->assertStringContainsString('Invalid argument: $order', $e->getMessage());
             }
         }
     }
@@ -493,7 +476,7 @@ class PageTest extends TestCase
             $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $resource', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $resource', $e->getMessage());
         }
     }
 
@@ -509,7 +492,7 @@ class PageTest extends TestCase
             $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $resource', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $resource', $e->getMessage());
         }
     }
 
@@ -788,7 +771,7 @@ class PageTest extends TestCase
             unset($page->uri);
             $this->fail('Should not be possible to unset native properties');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Unsetting native property', $e->getMessage());
+            $this->assertStringContainsString('Unsetting native property', $e->getMessage());
         }
     }
 
@@ -977,7 +960,7 @@ class PageTest extends TestCase
             $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $relations', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $relations', $e->getMessage());
         }
     }
 
@@ -1035,7 +1018,7 @@ class PageTest extends TestCase
             $this->fail('An invalid value was set, but a ' .
                         'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
         } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertContains('Invalid argument: $relations', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $relations', $e->getMessage());
         }
     }
 
@@ -1209,7 +1192,7 @@ class PageTest extends TestCase
         ]);
 
         $page->setPermission(['my_permission', 'other_permission']);
-        $this->assertInternalType('array', $page->getPermission());
+        $this->assertIsArray($page->getPermission());
         $this->assertCount(2, $page->getPermission());
     }
 

--- a/test/Service/AbstractNavigationFactoryTest.php
+++ b/test/Service/AbstractNavigationFactoryTest.php
@@ -15,9 +15,9 @@ use Laminas\Navigation\Exception;
 use Laminas\Navigation\Navigation;
 use Laminas\Navigation\Service\AbstractNavigationFactory;
 use Laminas\Router;
-use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionMethod;
 
 /**
@@ -27,7 +27,9 @@ use ReflectionMethod;
  */
 class AbstractNavigationFactoryTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->factory = new TestAsset\TestNavigationFactory();
     }

--- a/test/ServiceFactoryTest.php
+++ b/test/ServiceFactoryTest.php
@@ -12,7 +12,6 @@ use Laminas\Config\Config;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
-use Laminas\Navigation;
 use Laminas\Navigation\Page\Mvc as MvcPage;
 use Laminas\Navigation\Service\ConstructedNavigationFactory;
 use Laminas\Navigation\Service\DefaultNavigationFactory;
@@ -21,6 +20,7 @@ use Laminas\Router\RouteMatch;
 use Laminas\Router\RouteStackInterface;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the class Laminas\Navigation\MvcNavigationFactory
@@ -29,6 +29,8 @@ use PHPUnit\Framework\TestCase;
  */
 class ServiceFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var \Laminas\ServiceManager\ServiceManager
      */
@@ -37,7 +39,7 @@ class ServiceFactoryTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $config = [
             'navigation' => [


### PR DESCRIPTION
Signed-off-by: Oliver Peters <oliver_pet@web.de>

|    Q          |   A
|-------------- | ------
| BC Break      | yes

### Description

adds support for PHP 8.0
drop support for PHP versions < 7.3
update phpunit to 9.3