### PR TITLE
Adds a delegator to set ACL for helpers

### DIFF
--- a/src/View/PermissionAclDelegatorFactory.php
+++ b/src/View/PermissionAclDelegatorFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-navigation for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-navigation/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-navigation/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Navigation\View;
+
+use Laminas\Permissions\Acl\AclInterface;
+use Laminas\View\Helper\Navigation\AbstractHelper;
+use Psr\Container\ContainerInterface;
+
+class PermissionAclDelegatorFactory
+{
+    /** @var string */
+    private $aclName;
+
+    public function __construct(string $aclName = AclInterface::class)
+    {
+        $this->aclName = $aclName;
+    }
+
+    public static function __set_state(array $state): self
+    {
+        return new self($state['aclName'] ?? AclInterface::class);
+    }
+
+    public function __invoke(
+        ContainerInterface $container,
+        string $name,
+        callable $callback,
+        array $options = null
+    ) {
+        /** @var AbstractHelper|mixed $instance */
+        $helper = $callback();
+
+        if (! $helper instanceof AbstractHelper) {
+            return $helper;
+        }
+        if (! $container->has($this->aclName)) {
+            return $helper;
+        }
+
+        $acl = $container->get($this->aclName);
+        if (! $acl instanceof AclInterface) {
+            return $helper;
+        }
+
+        $helper->setAcl($acl);
+
+        return $helper;
+    }
+}

--- a/test/View/PermissionAclDelegatorFactoryTest.php
+++ b/test/View/PermissionAclDelegatorFactoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-navigation for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-navigation/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-navigation/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Navigation\View;
+
+use Laminas\Navigation\View\PermissionAclDelegatorFactory;
+use Laminas\Permissions\Acl\AclInterface;
+use Laminas\View\Helper\Navigation;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use stdClass;
+
+class PermissionAclDelegatorFactoryTest extends TestCase
+{
+    public function testAclShouldBeSetForHelper(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('has')
+            ->with(AclInterface::class)
+            ->willReturn(true);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(AclInterface::class)
+            ->willReturn($this->createMock(AclInterface::class));
+
+        $callback = static function () {
+            return new Navigation();
+        };
+
+        /** @var Navigation $result */
+        $result = (new PermissionAclDelegatorFactory())(
+            $container,
+            'name',
+            $callback
+        );
+
+        $this->assertInstanceOf(
+            AclInterface::class,
+            $result->getAcl()
+        );
+    }
+
+    public function testAclWithCustomNameShouldBeSetForHelper(): void
+    {
+        $customName = 'alternate-acl';
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('has')
+            ->with($customName)
+            ->willReturn(true);
+        $container->expects($this->once())
+            ->method('get')
+            ->with($customName)
+            ->willReturn($this->createMock(AclInterface::class));
+
+        $callback = static function () {
+            return new Navigation();
+        };
+
+        /** @var Navigation $result */
+        $result = (new PermissionAclDelegatorFactory($customName))(
+            $container,
+            'name',
+            $callback
+        );
+
+        $this->assertInstanceOf(
+            AclInterface::class,
+            $result->getAcl()
+        );
+    }
+
+    public function testNoneNavigationHelperPassedAsGiven(): void
+    {
+        $class = new stdClass();
+
+        $callback = static function () use ($class) {
+            return $class;
+        };
+
+        /** @var Navigation $result */
+        $result = (new PermissionAclDelegatorFactory())(
+            $this->createMock(ContainerInterface::class),
+            'name',
+            $callback
+        );
+
+        $this->assertSame($class, $result);
+    }
+
+    public function testNoneExistingAclWillHelperPassedAsGiven(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('has')
+            ->with(AclInterface::class)
+            ->willReturn(false);
+
+        $callback = static function () {
+            return new Navigation();
+        };
+
+        /** @var Navigation $result */
+        $result = (new PermissionAclDelegatorFactory())(
+            $container,
+            'name',
+            $callback
+        );
+
+        $this->assertNull($result->getAcl());
+    }
+
+    public function testWrongAclWillHelperPassedAsGiven(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('has')
+            ->with(AclInterface::class)
+            ->willReturn(true);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(AclInterface::class)
+            ->willReturn(null);
+
+        $callback = static function () {
+            return new Navigation();
+        };
+
+        /** @var Navigation $result */
+        $result = (new PermissionAclDelegatorFactory())(
+            $container,
+            'name',
+            $callback
+        );
+
+        $this->assertNull($result->getAcl());
+    }
+
+    public function testMagicMethodSetStateShouldContainAclClassName(): void
+    {
+        $this->assertStringContainsString(
+            'Laminas\\\Permissions\\\Acl\\\AclInterface',
+            var_export(new PermissionAclDelegatorFactory(), true)
+        );
+    }
+
+    public function testMagicMethodSetStateShouldContainCustomNameIfSet(): void
+    {
+        $customName = 'alternate-name';
+
+        $this->assertStringContainsString(
+            $customName,
+            var_export(new PermissionAclDelegatorFactory($customName), true)
+        );
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

The delegator allows the setting of a ACL for navigation helpers by using a registered `Laminas\Permissions\Acl\AclInterface` service.

### Example of Usage

```php
'navigation_helpers' => [
    'delegators' => [
        Laminas\View\Helper\Navigation::class => [
            Laminas\Navigation\View\PermissionAclDelegatorFactory::class,
        ],
    ],
],
```