### PR TITLE
Fix `preparePages()`’s return type

### DIFF
--- a/src/Service/AbstractNavigationFactory.php
+++ b/src/Service/AbstractNavigationFactory.php
@@ -92,7 +92,7 @@ abstract class AbstractNavigationFactory implements FactoryInterface
     /**
      * @param ContainerInterface $container
      * @param array|\Laminas\Config\Config $pages
-     * @return null|array
+     * @return array
      * @throws \Laminas\Navigation\Exception\InvalidArgumentException
      */
     protected function preparePages(ContainerInterface $container, $pages)


### PR DESCRIPTION
The method’s return type was set to `null|array`. `preparePages()` internally calls `injectComponents()` and returns the call’s result. `injectComponents()` always returns an array or throws an exception. Set the `preparePages()`’s return type to just `array`.

|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | no
| RFC           | no
| QA            | no