### PR TITLE
Adds laminas-mvc in the conflict section of the Composer file for versions smaller than 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "static-analysis": "psalm --shepherd --stats"
     },
     "conflict": {
+        "laminas/laminas-mvc": "<3.0.0",
         "zendframework/zend-navigation": "*"
     }
 }


### PR DESCRIPTION
The conflict definition was missed during updates in the past.

Fixes #29 