### PR TITLE
Test modernization

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -58,11 +58,6 @@
       <code><![CDATA[\Zend\Navigation\Navigation]]></code>
     </UndefinedClass>
   </file>
-  <file src="src/Module.php">
-    <UnusedClass>
-      <code><![CDATA[Module]]></code>
-    </UnusedClass>
-  </file>
   <file src="src/Navigation.php">
     <DocblockTypeContradiction>
       <code><![CDATA[$pages !== null && (! is_array($pages) && ! $pages instanceof Traversable)]]></code>
@@ -209,9 +204,7 @@
       <code><![CDATA[null]]></code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyUnusedMethod>
-      <code><![CDATA[getDefaultRoute]]></code>
       <code><![CDATA[getQuery]]></code>
-      <code><![CDATA[setRoute]]></code>
     </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$action]]></code>
@@ -440,12 +433,6 @@
     <DeprecatedInterface>
       <code><![CDATA[HelperConfig]]></code>
     </DeprecatedInterface>
-    <DeprecatedMethod>
-      <code><![CDATA[getServiceLocator]]></code>
-    </DeprecatedMethod>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$container->getServiceLocator() ?: $container]]></code>
-    </LessSpecificReturnStatement>
     <MissingClosureParamType>
       <code><![CDATA[$container]]></code>
       <code><![CDATA[$name]]></code>
@@ -490,9 +477,6 @@
     <PossiblyUnusedReturnValue>
       <code><![CDATA[ServiceManager]]></code>
     </PossiblyUnusedReturnValue>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$container->getServiceLocator()]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/View/NavigationHelperFactory.php">
     <DeprecatedClass>
@@ -541,7 +525,12 @@
     </ParamNameMismatch>
   </file>
   <file src="test/ContainerTest.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[assertIsArray]]></code>
+    </DocblockTypeContradiction>
     <InvalidArgument>
+      <code><![CDATA['invalid string']]></code>
+      <code><![CDATA['invalid string']]></code>
       <code><![CDATA['ok']]></code>
       <code><![CDATA[1337]]></code>
       <code><![CDATA[new stdClass()]]></code>
@@ -561,6 +550,9 @@
     <MixedMethodCall>
       <code><![CDATA[getLabel]]></code>
     </MixedMethodCall>
+    <NoValue>
+      <code><![CDATA[$result]]></code>
+    </NoValue>
     <PossiblyNullArgument>
       <code><![CDATA[$container->findOneBy('route', 'bar')]]></code>
       <code><![CDATA[$container->findOneBy('route', 'baz')]]></code>
@@ -569,19 +561,6 @@
       <code><![CDATA[hasChildren]]></code>
       <code><![CDATA[hasChildren]]></code>
     </PossiblyNullReference>
-    <TooManyArguments>
-      <code><![CDATA[new AbstractContainer([
-            [
-                'label' => 'Page 2',
-                'type'  => 'uri',
-            ],
-            [
-                'label' => 'Page 1',
-                'type'  => 'uri',
-                'order' => -1,
-            ],
-        ])]]></code>
-    </TooManyArguments>
     <UndefinedMagicMethod>
       <code><![CDATA[findAllByAction]]></code>
       <code><![CDATA[findAllById]]></code>
@@ -593,12 +572,20 @@
       <code><![CDATA[getPagez]]></code>
     </UndefinedMagicMethod>
   </file>
+  <file src="test/ModuleTest.php">
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[assertIsArray]]></code>
+    </RedundantConditionGivenDocblockType>
+  </file>
   <file src="test/NavigationTest.php">
     <PossiblyNullPropertyAssignmentValue>
       <code><![CDATA[null]]></code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Page/MvcTest.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[(object) ['invalid' => 'object']]]></code>
+    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$newRouter]]></code>
       <code><![CDATA[$router]]></code>
@@ -610,17 +597,25 @@
       <code><![CDATA[$router]]></code>
       <code><![CDATA[TreeRouteStack::class]]></code>
     </InvalidArgument>
+    <MixedArgument>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedArgument>
     <NullArgument>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
     </NullArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-    </PossiblyInvalidCast>
     <PossiblyNullArgument>
       <code><![CDATA[$event->getRouteMatch()]]></code>
       <code><![CDATA[$event->getRouteMatch()]]></code>
@@ -628,6 +623,9 @@
       <code><![CDATA[$event->getRouteMatch()]]></code>
       <code><![CDATA[$event->getRouteMatch()]]></code>
     </PossiblyNullArgument>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[assertIsString]]></code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Page/PageFactoryTest.php">
     <MissingClosureParamType>
@@ -646,31 +644,30 @@
       <code><![CDATA[assertSame]]></code>
     </DocblockTypeContradiction>
     <InvalidArgument>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
       <code><![CDATA['False']]></code>
       <code><![CDATA['alternate']]></code>
       <code><![CDATA['alternate']]></code>
       <code><![CDATA['true']]></code>
       <code><![CDATA[0]]></code>
       <code><![CDATA[0]]></code>
-      <code><![CDATA[0]]></code>
       <code><![CDATA[1]]></code>
       <code><![CDATA[1]]></code>
       <code><![CDATA[[]]]></code>
       <code><![CDATA[[]]]></code>
-      <code><![CDATA[new stdClass()]]></code>
     </InvalidArgument>
     <InvalidCast>
       <code><![CDATA[[]]]></code>
       <code><![CDATA[[]]]></code>
     </InvalidCast>
     <MixedArgument>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
+      <code><![CDATA[$invalid]]></code>
       <code><![CDATA[$page->getPermission()]]></code>
     </MixedArgument>
     <MixedAssignment>
@@ -686,10 +683,6 @@
     <MixedPropertyFetch>
       <code><![CDATA[$page->getPermission()->name]]></code>
     </MixedPropertyFetch>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$invalid]]></code>
-    </PossiblyInvalidCast>
     <PossiblyNullArgument>
       <code><![CDATA[$page->getPermission()]]></code>
     </PossiblyNullArgument>
@@ -775,7 +768,13 @@
   <file src="test/View/HelperConfigTest.php">
     <DeprecatedClass>
       <code><![CDATA[NavigationHelper::class]]></code>
+      <code><![CDATA[NavigationHelper::class]]></code>
+      <code><![CDATA[NavigationHelper::class]]></code>
       <code><![CDATA[NavigationHelper\Links::class]]></code>
+      <code><![CDATA[NavigationHelper\Menu::class]]></code>
+      <code><![CDATA[NavigationHelper\Menu::class]]></code>
+      <code><![CDATA[NavigationHelper\Menu::class]]></code>
+      <code><![CDATA[NavigationHelper\Menu::class]]></code>
     </DeprecatedClass>
     <MissingClosureParamType>
       <code><![CDATA[$services]]></code>
@@ -784,12 +783,30 @@
       <code><![CDATA[$helpers]]></code>
       <code><![CDATA[$services]]></code>
     </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$internalConfig['delegators']]]></code>
+      <code><![CDATA[$internalConfig['delegators'][NavigationHelperFactory::class]]]></code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment>
+      <code><![CDATA[$internalConfig['delegators']]]></code>
+      <code><![CDATA[$internalConfig['delegators'][NavigationHelperFactory::class]]]></code>
+    </MixedArrayAssignment>
     <MixedAssignment>
+      <code><![CDATA[$factory]]></code>
       <code><![CDATA[$helpers]]></code>
+      <code><![CDATA[$internalConfig]]></code>
+      <code><![CDATA[$internalConfig['delegators'][NavigationHelperFactory::class][]]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[findHelper]]></code>
     </MixedMethodCall>
+  </file>
+  <file src="test/View/NavigationHelperFactoryTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[NavigationHelper::class]]></code>
+      <code><![CDATA[NavigationHelper::class]]></code>
+      <code><![CDATA[NavigationHelper::class]]></code>
+    </DeprecatedClass>
   </file>
   <file src="test/View/ViewHelperManagerDelegatorFactoryTest.php">
     <DeprecatedClass>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -344,9 +344,6 @@
       <code><![CDATA[$invalid]]></code>
       <code><![CDATA[$invalid]]></code>
       <code><![CDATA[$invalid]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <NullArgument>
       <code><![CDATA[null]]></code>

--- a/src/View/HelperConfig.php
+++ b/src/View/HelperConfig.php
@@ -17,7 +17,6 @@ use Traversable;
 use function in_array;
 use function is_array;
 use function iterator_to_array;
-use function method_exists;
 use function strtolower;
 use function strtr;
 
@@ -151,17 +150,8 @@ class HelperConfig extends Config
      */
     private function getParentContainer(ServiceManager $container)
     {
-        // We need the parent container in order to retrieve the config
-        // service. We should likely revisit how this is done in the future.
-        //
-        // v3:
-        if (method_exists($container, 'configure')) {
-            $r = new ReflectionProperty($container, 'creationContext');
-            return $r->getValue($container) ?: $container;
-        }
-
-        // v2:
-        return $container->getServiceLocator() ?: $container;
+        $r = new ReflectionProperty($container, 'creationContext');
+        return $r->getValue($container) ?: $container;
     }
 
     /**

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -66,34 +66,25 @@ final class ContainerTest extends TestCase
         $this->assertEquals(3, $container->count());
     }
 
-    public function testConstructorShouldThrowExceptionOnInvalidArgument(): void
+    public function testConstructorShouldThrowExceptionOnStringArgument(): void
     {
-        try {
-            new Navigation\Navigation('ok');
-            $this->fail('An invalid argument was given to the constructor, '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $pages', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $pages');
+        new Navigation\Navigation('ok');
+    }
 
-        try {
-            new Navigation\Navigation(1337);
-            $this->fail('An invalid argument was given to the constructor, '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $pages', $e->getMessage());
-        }
+    public function testConstructorShouldThrowExceptionOnIntegerArgument(): void
+    {
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $pages');
+        new Navigation\Navigation(1337);
+    }
 
-        try {
-            new Navigation\Navigation(new stdClass());
-            $this->fail('An invalid argument was given to the constructor, '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\ExceptionInterface $e) {
-            $this->assertStringContainsString('Invalid argument: $pages', $e->getMessage());
-        }
+    public function testConstructorShouldThrowExceptionOnObjectArgument(): void
+    {
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $pages');
+        new Navigation\Navigation(new stdClass());
     }
 
     public function testAddPagesWithNullValueSkipsPage(): void
@@ -512,30 +503,20 @@ final class ContainerTest extends TestCase
     {
         $nav = new Navigation\Navigation();
 
-        try {
-            /** @psalm-suppress InvalidArgument */
-            $nav->addPages('this is a string');
-            $this->fail('An invalid argument was given to addPages(), '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $pages must be', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $pages must be');
+        /** @psalm-suppress InvalidArgument */
+        $nav->addPages('this is a string');
     }
 
     public function testAddPagesShouldThrowExceptionWhenGivenAnArbitraryObject(): void
     {
         $nav = new Navigation\Navigation();
 
-        try {
-            /** @psalm-suppress InvalidArgument */
-            $nav->addPages($pages = new stdClass());
-            $this->fail('An invalid argument was given to addPages(), '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $pages must be', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $pages must be');
+        /** @psalm-suppress InvalidArgument */
+        $nav->addPages(new stdClass());
     }
 
     public function testRemovingAllPages(): void
@@ -714,7 +695,7 @@ final class ContainerTest extends TestCase
 
         $nav->addPage($page3);
 
-        $this->assertEquals(true, $nav->removePage($page3));
+        $this->assertTrue($nav->removePage($page3));
     }
 
     public function testRemovingPageByInstanceShouldReturnFalseIfPageIsNotInContainer(): void
@@ -735,7 +716,7 @@ final class ContainerTest extends TestCase
             'uri'   => '#',
         ]);
 
-        $this->assertEquals(false, $nav->removePage($page));
+        $this->assertFalse($nav->removePage($page));
     }
 
     public function testHasPage(): void
@@ -891,7 +872,7 @@ final class ContainerTest extends TestCase
         $page2->setParent($page1);
         $page2->setParent(null);
 
-        $this->assertEquals(null, $page2->getParent());
+        $this->assertNull($page2->getParent());
     }
 
     public function testSetParentShouldRemoveFromOldParentPage(): void
@@ -1115,28 +1096,18 @@ final class ContainerTest extends TestCase
     {
         $nav = $this->_getFindByNavigation();
 
-        try {
-            $nav->findSomeById('page_2_and_3');
-            $this->fail('An invalid magic finder method was used, '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\BadMethodCallException $e) {
-            $this->assertStringContainsString('Bad method call', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\BadMethodCallException::class);
+        $this->expectExceptionMessage('Bad method call');
+        $nav->findSomeById('page_2_and_3');
     }
 
     public function testInvalidMagicMethodShouldThrowException(): void
     {
         $nav = $this->_getFindByNavigation();
 
-        try {
-            $nav->getPagez();
-            $this->fail('An invalid magic finder method was used, '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\BadMethodCallException $e) {
-            $this->assertStringContainsString('Bad method call', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\BadMethodCallException::class);
+        $this->expectExceptionMessage('Bad method call');
+        $nav->getPagez();
     }
 
     // @codingStandardsIgnoreStart
@@ -1215,32 +1186,21 @@ final class ContainerTest extends TestCase
 
     public function testCurrentShouldThrowExceptionIfIndexIsInvalid(): void
     {
-        $container = new AbstractContainer([
-            [
-                'label' => 'Page 2',
-                'type'  => 'uri',
-            ],
-            [
-                'label' => 'Page 1',
-                'type'  => 'uri',
-                'order' => -1,
-            ],
+        $container = new AbstractContainer();
+        $container->addPage([
+            'label' => 'Page 1',
+            'type'  => 'uri',
         ]);
 
-        try {
-            $container->current();
-            $this->fail('AbstractContainer index is invalid, '
-                        . 'but a Laminas\Navigation\Exception\InvalidArgumentException was '
-                        . 'not thrown');
-        } catch (Navigation\Exception\OutOfBoundsException $e) {
-            $this->assertStringContainsString('Corruption detected', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Corruption detected');
+        $container->current();
     }
 
     public function testKeyWhenContainerIsEmpty(): void
     {
         $container = new Navigation\Navigation();
-        $this->assertEquals(null, $container->key());
+        $this->assertNull($container->key());
     }
 
     public function testKeyShouldReturnCurrentPageHash(): void
@@ -1269,7 +1229,7 @@ final class ContainerTest extends TestCase
     {
         $container = new Navigation\Navigation();
 
-        $this->assertEquals(null, $container->getChildren());
+        $this->assertNull($container->getChildren());
     }
 
     #[Group('GH-5929')]
@@ -1295,5 +1255,132 @@ final class ContainerTest extends TestCase
         $this->assertNull($container->findOneBy('route', 'baz'));
         $container->removePage($container->findOneBy('route', 'bar'), true);
         $this->assertNull($container->findOneBy('route', 'bar'));
+    }
+
+    public function testModifyOrderUpdatedTriggersResort(): void
+    {
+        $container = new Navigation\Navigation();
+
+        $page1 = Page\AbstractPage::factory(['label' => 'Page 1', 'uri' => '#', 'order' => 10]);
+        $page2 = Page\AbstractPage::factory(['label' => 'Page 2', 'uri' => '#', 'order' => 5]);
+
+        $container->addPage($page1);
+        $container->addPage($page2);
+
+        $container->rewind();
+        $this->assertSame('Page 2', $container->current()->getLabel());
+
+        $page2->setOrder(20);
+
+        $container->rewind();
+        $this->assertSame('Page 1', $container->current()->getLabel());
+    }
+
+    public function testHasChildrenReturnsTrueWhenCurrentPageHasChildren(): void
+    {
+        $container = new Navigation\Navigation([
+            [
+                'label' => 'Parent',
+                'uri'   => '#',
+                'pages' => [
+                    ['label' => 'Child', 'uri' => '#'],
+                ],
+            ],
+        ]);
+
+        $container->rewind();
+        $this->assertTrue($container->hasChildren());
+    }
+
+    public function testHasChildrenReturnsFalseWhenCurrentPageHasNoChildren(): void
+    {
+        $container = new Navigation\Navigation([
+            ['label' => 'Page without children', 'uri' => '#'],
+        ]);
+
+        $container->rewind();
+        $this->assertFalse($container->hasChildren());
+    }
+
+    public function testGetChildrenReturnsCurrentPage(): void
+    {
+        $container = new Navigation\Navigation([
+            [
+                'label' => 'Parent',
+                'uri'   => '#',
+                'pages' => [
+                    ['label' => 'Child', 'uri' => '#'],
+                ],
+            ],
+        ]);
+
+        $container->rewind();
+        $children = $container->getChildren();
+
+        $this->assertInstanceOf(Page\AbstractPage::class, $children);
+        $this->assertSame('Parent', $children->getLabel());
+    }
+
+    public function testAddPageThrowsExceptionWhenAddingContainerToItself(): void
+    {
+        $container = new Navigation\Navigation();
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A page cannot have itself as a parent');
+        $container->addPage($container);
+    }
+
+    public function testAddPageThrowsExceptionForInvalidType(): void
+    {
+        $container = new Navigation\Navigation();
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $page must be an instance of');
+        $container->addPage('invalid string');
+    }
+
+    public function testAddPageReturnsSameInstanceWhenAddingDuplicatePage(): void
+    {
+        $container = new Navigation\Navigation();
+        $page      = Page\AbstractPage::factory(['label' => 'Test', 'uri' => '#']);
+
+        $result1 = $container->addPage($page);
+        $result2 = $container->addPage($page);
+
+        $this->assertSame($container, $result1);
+        $this->assertSame($container, $result2);
+        $this->assertCount(1, $container);
+    }
+
+    public function testRemovePageReturnsFalseForInvalidType(): void
+    {
+        $container = new Navigation\Navigation([
+            ['label' => 'Page 1', 'uri' => '#'],
+        ]);
+
+        $this->assertFalse($container->removePage('invalid string'));
+    }
+
+    public function testHasPagesWithOnlyVisibleReturnsTrue(): void
+    {
+        $container = new Navigation\Navigation([
+            ['label' => 'Visible Page', 'uri' => '#', 'visible' => true],
+        ]);
+
+        $this->assertTrue($container->hasPages(true));
+    }
+
+    public function testFindByWithAllTrueReturnsArray(): void
+    {
+        $container = new Navigation\Navigation([
+            ['label' => 'Page 1', 'uri' => '#', 'class' => 'nav-item'],
+            ['label' => 'Page 2', 'uri' => '#', 'class' => 'nav-item'],
+            ['label' => 'Page 3', 'uri' => '#', 'class' => 'other'],
+        ]);
+
+        $result = $container->findBy('class', 'nav-item', true);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
     }
 }

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Navigation;
+
+use Laminas\Navigation\Module;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleTest extends TestCase
+{
+    public function testGetConfigReturnsArray(): void
+    {
+        $module = new Module();
+        $config = $module->getConfig();
+
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('service_manager', $config);
+        $this->assertIsArray($config['service_manager']);
+    }
+}

--- a/test/Page/MvcTest.php
+++ b/test/Page/MvcTest.php
@@ -92,7 +92,7 @@ final class MvcTest extends TestCase
             'use_route_match' => true,
         ]);
         $router = $this->createMock(TreeRouteStack::class);
-        $router->expects($this->once())->method('assemble')->willReturn('/test/route');
+        $router->expects(self::once())->method('assemble')->willReturn('/test/route');
         $page->setRouter($router);
         $this->assertEquals('/test/route', $page->getHref());
     }

--- a/test/Page/MvcTest.php
+++ b/test/Page/MvcTest.php
@@ -35,6 +35,9 @@ final class MvcTest extends TestCase
 
     protected function setUp(): void
     {
+        Page\Mvc::setDefaultRoute(null);
+        Page\Mvc::setDefaultRouter(null);
+
         $this->route = new RegexRoute(
             '((?<controller>[^/]+)(/(?<action>[^/]+))?)',
             '/%controller%/%action%',
@@ -377,7 +380,7 @@ final class MvcTest extends TestCase
         $this->assertFalse($page->isActive());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return array<string, array{0: string|null}> */
     public static function validActionValueProvider(): array
     {
         return [
@@ -393,7 +396,7 @@ final class MvcTest extends TestCase
     }
 
     #[DataProvider('validActionValueProvider')]
-    public function testSetActionAcceptsValidValue(mixed $value): void
+    public function testSetActionAcceptsValidValue(string|null $value): void
     {
         $page = new Page\Mvc([
             'label'      => 'foo',
@@ -405,7 +408,7 @@ final class MvcTest extends TestCase
         $this->assertSame($value, $page->getAction());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return array<string, array{0: string|null}> */
     public static function validControllerValueProvider(): array
     {
         return [
@@ -421,7 +424,7 @@ final class MvcTest extends TestCase
     }
 
     #[DataProvider('validControllerValueProvider')]
-    public function testSetControllerAcceptsValidValue(mixed $value): void
+    public function testSetControllerAcceptsValidValue(string|null $value): void
     {
         $page = new Page\Mvc([
             'label'      => 'foo',
@@ -499,7 +502,7 @@ final class MvcTest extends TestCase
         $page->setRoute($invalid);
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return array<string, array{0: string|null}> */
     public static function validRouteValueProvider(): array
     {
         return [
@@ -514,7 +517,7 @@ final class MvcTest extends TestCase
     }
 
     #[DataProvider('validRouteValueProvider')]
-    public function testSetRouteAcceptsValidValue(mixed $value): void
+    public function testSetRouteAcceptsValidValue(string|null $value): void
     {
         $page = new Page\Mvc([
             'label'      => 'foo',
@@ -909,9 +912,6 @@ final class MvcTest extends TestCase
 
     public function testGetHrefThrowsExceptionWhenNoRouteName(): void
     {
-        Page\Mvc::setDefaultRoute(null);
-        Page\Mvc::setDefaultRouter(null);
-
         $page = new Page\Mvc([
             'label' => 'foo',
         ]);

--- a/test/Page/MvcTest.php
+++ b/test/Page/MvcTest.php
@@ -17,6 +17,7 @@ use Laminas\Router\Http\Segment as SegmentRoute;
 use Laminas\Router\Http\TreeRouteStack;
 use Laminas\Router\RouteMatch;
 use LaminasTest\Navigation\TestAsset;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -147,7 +148,7 @@ final class MvcTest extends TestCase
         $page->setRouter($router);
         $page->setRouteMatch($routeMatch);
 
-        $this->assertEquals(true, $page->isActive());
+        $this->assertTrue($page->isActive());
     }
 
     public function testIsActiveReturnsTrueWhenMatchingRouteWhileUsingModuleRouteListener(): void
@@ -179,7 +180,7 @@ final class MvcTest extends TestCase
         $page->setRouter($event->getRouter());
         $page->setRouteMatch($event->getRouteMatch());
 
-        $this->assertEquals(true, $page->isActive());
+        $this->assertTrue($page->isActive());
     }
 
     public function testIsActiveReturnsFalseWhenMatchingRouteButNonMatchingParams(): void
@@ -374,40 +375,23 @@ final class MvcTest extends TestCase
         $this->assertFalse($page->isActive());
     }
 
-    public function testActionAndControllerAccessors(): void
+    /** @return array<string, array{0: mixed}> */
+    public static function validActionValueProvider(): array
     {
-        $page = new Page\Mvc([
-            'label'      => 'foo',
-            'action'     => 'index',
-            'controller' => 'index',
-        ]);
-
-        $props    = ['Action', 'Controller'];
-        $valids   = ['index', 'help', 'home', 'default', '1', ' ', '', null];
-        $invalids = [42, (object) null];
-
-        foreach ($props as $prop) {
-            $setter = "set$prop";
-            $getter = "get$prop";
-
-            foreach ($valids as $valid) {
-                $page->$setter($valid);
-                $this->assertEquals($valid, $page->$getter());
-            }
-
-            foreach ($invalids as $invalid) {
-                try {
-                    $page->$setter($invalid);
-                    $msg  = "'$invalid' is invalid for $setter(), but no ";
-                    $msg .= 'Laminas\Navigation\Exception\InvalidArgumentException was thrown';
-                    $this->fail($msg);
-                } catch (Navigation\Exception\InvalidArgumentException) {
-                }
-            }
-        }
+        return [
+            'string-index'   => ['index'],
+            'string-help'    => ['help'],
+            'string-home'    => ['home'],
+            'string-default' => ['default'],
+            'string-1'       => ['1'],
+            'string-space'   => [' '],
+            'string-empty'   => [''],
+            'null'           => [null],
+        ];
     }
 
-    public function testRouteAccessor(): void
+    #[DataProvider('validActionValueProvider')]
+    public function testSetActionAcceptsValidValue(mixed $value): void
     {
         $page = new Page\Mvc([
             'label'      => 'foo',
@@ -415,29 +399,129 @@ final class MvcTest extends TestCase
             'controller' => 'index',
         ]);
 
-        $props    = ['Route'];
-        $valids   = ['index', 'help', 'home', 'default', '1', ' ', null];
-        $invalids = [42, (object) null];
+        $page->setAction($value);
+        $this->assertSame($value, $page->getAction());
+    }
 
-        foreach ($props as $prop) {
-            $setter = "set$prop";
-            $getter = "get$prop";
+    /** @return array<string, array{0: mixed}> */
+    public static function validControllerValueProvider(): array
+    {
+        return [
+            'string-index'   => ['index'],
+            'string-help'    => ['help'],
+            'string-home'    => ['home'],
+            'string-default' => ['default'],
+            'string-1'       => ['1'],
+            'string-space'   => [' '],
+            'string-empty'   => [''],
+            'null'           => [null],
+        ];
+    }
 
-            foreach ($valids as $valid) {
-                $page->$setter($valid);
-                $this->assertEquals($valid, $page->$getter());
-            }
+    #[DataProvider('validControllerValueProvider')]
+    public function testSetControllerAcceptsValidValue(mixed $value): void
+    {
+        $page = new Page\Mvc([
+            'label'      => 'foo',
+            'action'     => 'index',
+            'controller' => 'index',
+        ]);
 
-            foreach ($invalids as $invalid) {
-                try {
-                    $page->$setter($invalid);
-                    $msg  = "'$invalid' is invalid for $setter(), but no ";
-                    $msg .= 'Laminas\Navigation\Exception\InvalidArgumentException was thrown';
-                    $this->fail($msg);
-                } catch (Navigation\Exception\InvalidArgumentException) {
-                }
-            }
-        }
+        $page->setController($value);
+        $this->assertSame($value, $page->getController());
+    }
+
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidActionValueProvider(): array
+    {
+        return [
+            'integer' => [42],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidActionValueProvider')]
+    public function testSetActionThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = new Page\Mvc([
+            'label'      => 'foo',
+            'action'     => 'index',
+            'controller' => 'index',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $page->setAction($invalid);
+    }
+
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidControllerValueProvider(): array
+    {
+        return [
+            'integer' => [42],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidControllerValueProvider')]
+    public function testSetControllerThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = new Page\Mvc([
+            'label'      => 'foo',
+            'action'     => 'index',
+            'controller' => 'index',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $page->setController($invalid);
+    }
+
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidRouteValueProvider(): array
+    {
+        return [
+            'integer' => [42],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidRouteValueProvider')]
+    public function testSetRouteThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = new Page\Mvc([
+            'label'      => 'foo',
+            'action'     => 'index',
+            'controller' => 'index',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $page->setRoute($invalid);
+    }
+
+    /** @return array<string, array{0: mixed}> */
+    public static function validRouteValueProvider(): array
+    {
+        return [
+            'string-index'   => ['index'],
+            'string-help'    => ['help'],
+            'string-home'    => ['home'],
+            'string-default' => ['default'],
+            'string-1'       => ['1'],
+            'string-space'   => [' '],
+            'null'           => [null],
+        ];
+    }
+
+    #[DataProvider('validRouteValueProvider')]
+    public function testSetRouteAcceptsValidValue(mixed $value): void
+    {
+        $page = new Page\Mvc([
+            'label'      => 'foo',
+            'action'     => 'index',
+            'controller' => 'index',
+        ]);
+
+        $page->setRoute($value);
+        $this->assertSame($value, $page->getRoute());
     }
 
     public function testSetAndGetParams(): void
@@ -565,19 +649,19 @@ final class MvcTest extends TestCase
         $page = new Page\Mvc([
             'useRouteMatch' => 2,
         ]);
-        $this->assertSame(true, $page->useRouteMatch());
+        $this->assertTrue($page->useRouteMatch());
 
         $page->setUseRouteMatch(null);
-        $this->assertSame(false, $page->useRouteMatch());
+        $this->assertFalse($page->useRouteMatch());
 
         $page->setUseRouteMatch(false);
-        $this->assertSame(false, $page->useRouteMatch());
+        $this->assertFalse($page->useRouteMatch());
 
         $page->setUseRouteMatch(true);
-        $this->assertSame(true, $page->useRouteMatch());
+        $this->assertTrue($page->useRouteMatch());
 
         $page->setUseRouteMatch();
-        $this->assertSame(true, $page->useRouteMatch());
+        $this->assertTrue($page->useRouteMatch());
     }
 
     public function testMvcPageParamsInheritRouteMatchParams(): void
@@ -751,5 +835,90 @@ final class MvcTest extends TestCase
         $page = new Page\Mvc();
         $page->setRouter(TreeRouteStack::class);
         $page->setRouteMatch(null);
+    }
+
+    public function testDefaultRouteCanBeSetAndRetrieved(): void
+    {
+        $originalRoute = Page\Mvc::getDefaultRoute();
+
+        Page\Mvc::setDefaultRoute('custom-route');
+        $this->assertSame('custom-route', Page\Mvc::getDefaultRoute());
+
+        Page\Mvc::setDefaultRoute($originalRoute);
+    }
+
+    public function testGetHrefReturnsCachedValue(): void
+    {
+        $page = new Page\Mvc([
+            'label'  => 'foo',
+            'route'  => 'default',
+            'action' => 'index',
+        ]);
+        $page->setRouter($this->router);
+
+        $href1 = $page->getHref();
+        $href2 = $page->getHref();
+
+        $this->assertSame($href1, $href2);
+    }
+
+    public function testGetHrefThrowsExceptionWhenNoRouter(): void
+    {
+        Page\Mvc::setDefaultRouter(null);
+
+        $page = new Page\Mvc([
+            'label' => 'foo',
+            'route' => 'default',
+        ]);
+
+        $this->expectException(Exception\DomainException::class);
+        $this->expectExceptionMessage('cannot execute as no Laminas\Router\RouteStackInterface instance is composed');
+        $page->getHref();
+    }
+
+    public function testGetHrefUsesRouteMatchWhenNoRouteSet(): void
+    {
+        $originalDefaultRoute = Page\Mvc::getDefaultRoute();
+        Page\Mvc::setDefaultRoute(null);
+
+        $page = new Page\Mvc([
+            'label'      => 'foo',
+            'controller' => 'index',
+            'action'     => 'index',
+        ]);
+
+        $page->setRouteMatch($this->routeMatch);
+        $page->setRouter($this->router);
+
+        $href = $page->getHref();
+        $this->assertIsString($href);
+
+        Page\Mvc::setDefaultRoute($originalDefaultRoute);
+    }
+
+    public function testGetHrefThrowsExceptionWhenNoRouteName(): void
+    {
+        Page\Mvc::setDefaultRoute(null);
+        Page\Mvc::setDefaultRouter(null);
+
+        $page = new Page\Mvc([
+            'label' => 'foo',
+        ]);
+        $page->setRouter($this->router);
+
+        $this->expectException(Exception\DomainException::class);
+        $this->expectExceptionMessage('No route name could be found');
+        $page->getHref();
+    }
+
+    public function testSetRouteMatchThrowsExceptionForInvalidObject(): void
+    {
+        $page = new Page\Mvc([
+            'label' => 'foo',
+        ]);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('RouteMatch passed to');
+        $page->setRouteMatch((object) ['invalid' => 'object']);
     }
 }

--- a/test/Page/PageTest.php
+++ b/test/Page/PageTest.php
@@ -10,6 +10,7 @@ use Laminas\Navigation\Exception;
 use Laminas\Navigation\Page\AbstractPage;
 use Laminas\Navigation\Page\Uri;
 use Laminas\Permissions\Acl\Resource\GenericResource;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -142,17 +143,28 @@ final class PageTest extends TestCase
         $this->assertEquals('foo', $page->getLabel());
         $page->setLabel('bar');
         $this->assertEquals('bar', $page->getLabel());
+    }
 
-        $invalids = [42, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setLabel($invalid);
-                $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid argument: $label', $e->getMessage());
-            }
-        }
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidLabelProvider(): array
+    {
+        return [
+            'integer' => [42],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidLabelProvider')]
+    public function testSetLabelThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => '#',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $label');
+        $page->setLabel($invalid);
     }
 
     #[Group('Laminas-8922')]
@@ -167,20 +179,29 @@ final class PageTest extends TestCase
 
         $page->setFragment('bar');
         $this->assertEquals('bar', $page->getFragment());
+    }
 
-        $invalids = [42, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setFragment($invalid);
-                $this->fail('An invalid value was set, but a '
-                            . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString(
-                    'Invalid argument: $fragment',
-                    $e->getMessage()
-                );
-            }
-        }
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidFragmentProvider(): array
+    {
+        return [
+            'integer' => [42],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[Group('Laminas-8922')]
+    #[DataProvider('invalidFragmentProvider')]
+    public function testSetFragmentThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'uri'      => '#',
+            'fragment' => 'foo',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $fragment');
+        $page->setFragment($invalid);
     }
 
     public function testSetAndGetId(): void
@@ -190,21 +211,32 @@ final class PageTest extends TestCase
             'uri'   => '#',
         ]);
 
-        $this->assertEquals(null, $page->getId());
+        $this->assertNull($page->getId());
 
         $page->setId('bar');
         $this->assertEquals('bar', $page->getId());
+    }
 
-        $invalids = [true, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setId($invalid);
-                $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid argument: $id', $e->getMessage());
-            }
-        }
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidIdProvider(): array
+    {
+        return [
+            'boolean' => [true],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidIdProvider')]
+    public function testSetIdThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => '#',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $id');
+        $page->setId($invalid);
     }
 
     public function testIdCouldBeAnInteger(): void
@@ -225,20 +257,32 @@ final class PageTest extends TestCase
             'uri'   => '#',
         ]);
 
-        $this->assertEquals(null, $page->getClass());
+        $this->assertNull($page->getClass());
         $page->setClass('bar');
         $this->assertEquals('bar', $page->getClass());
+    }
 
-        $invalids = [42, true, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setClass($invalid);
-                $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid argument: $class', $e->getMessage());
-            }
-        }
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidStringPropertyProvider(): array
+    {
+        return [
+            'integer' => [42],
+            'boolean' => [true],
+            'object'  => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidStringPropertyProvider')]
+    public function testSetClassThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => '#',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $class');
+        $page->setClass($invalid);
     }
 
     public function testSetAndGetTitle(): void
@@ -248,20 +292,22 @@ final class PageTest extends TestCase
             'uri'   => '#',
         ]);
 
-        $this->assertEquals(null, $page->getTitle());
+        $this->assertNull($page->getTitle());
         $page->setTitle('bar');
         $this->assertEquals('bar', $page->getTitle());
+    }
 
-        $invalids = [42, true, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setTitle($invalid);
-                $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid argument: $title', $e->getMessage());
-            }
-        }
+    #[DataProvider('invalidStringPropertyProvider')]
+    public function testSetTitleThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => '#',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $title');
+        $page->setTitle($invalid);
     }
 
     public function testSetAndGetTarget(): void
@@ -271,20 +317,22 @@ final class PageTest extends TestCase
             'uri'   => '#',
         ]);
 
-        $this->assertEquals(null, $page->getTarget());
+        $this->assertNull($page->getTarget());
         $page->setTarget('bar');
         $this->assertEquals('bar', $page->getTarget());
+    }
 
-        $invalids = [42, true, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setTarget($invalid);
-                $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid argument: $target', $e->getMessage());
-            }
-        }
+    #[DataProvider('invalidStringPropertyProvider')]
+    public function testSetTargetThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => '#',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $target');
+        $page->setTarget($invalid);
     }
 
     public function testConstructingWithRelationsInArray(): void
@@ -396,7 +444,7 @@ final class PageTest extends TestCase
             'uri'   => '#',
         ]);
 
-        $this->assertEquals(null, $page->getOrder());
+        $this->assertNull($page->getOrder());
 
         $page->setOrder('1');
         $this->assertEquals(1, $page->getOrder());
@@ -406,17 +454,32 @@ final class PageTest extends TestCase
 
         $page->setOrder('-25');
         $this->assertEquals(-25, $page->getOrder());
+    }
 
-        $invalids = [3.14, 'e', "\n", '0,4', true, (object) null];
-        foreach ($invalids as $invalid) {
-            try {
-                $page->setOrder($invalid);
-                $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-            } catch (Navigation\Exception\InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid argument: $order', $e->getMessage());
-            }
-        }
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidOrderProvider(): array
+    {
+        return [
+            'float'        => [3.14],
+            'non-numeric'  => ['e'],
+            'newline'      => ["\n"],
+            'comma-format' => ['0,4'],
+            'boolean'      => [true],
+            'object'       => [(object) null],
+        ];
+    }
+
+    #[DataProvider('invalidOrderProvider')]
+    public function testSetOrderThrowsExceptionOnInvalidValue(mixed $invalid): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => '#',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $order');
+        $page->setOrder($invalid);
     }
 
     public function testSetResourceString(): void
@@ -439,7 +502,7 @@ final class PageTest extends TestCase
         ]);
 
         $page->setResource();
-        $this->assertEquals(null, $page->getResource());
+        $this->assertNull($page->getResource());
     }
 
     public function testSetResourceNull(): void
@@ -451,7 +514,7 @@ final class PageTest extends TestCase
         ]);
 
         $page->setResource(null);
-        $this->assertEquals(null, $page->getResource());
+        $this->assertNull($page->getResource());
     }
 
     public function testSetResourceInterface(): void
@@ -467,36 +530,26 @@ final class PageTest extends TestCase
         $this->assertEquals($resource, $page->getResource());
     }
 
-    public function testSetResourceShouldThrowExceptionWhenGivenInteger(): void
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidResourceProvider(): array
     {
-        $page = AbstractPage::factory([
-            'type'  => 'uri',
-            'label' => 'hello',
-        ]);
-
-        try {
-            $page->setResource(0);
-            $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $resource', $e->getMessage());
-        }
+        return [
+            'integer' => [0],
+            'object'  => [new stdClass()],
+        ];
     }
 
-    public function testSetResourceShouldThrowExceptionWhenGivenObject(): void
+    #[DataProvider('invalidResourceProvider')]
+    public function testSetResourceShouldThrowExceptionOnInvalidValue(mixed $invalid): void
     {
         $page = AbstractPage::factory([
             'type'  => 'uri',
             'label' => 'hello',
         ]);
 
-        try {
-            $page->setResource(new stdClass());
-            $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $resource', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $resource');
+        $page->setResource($invalid);
     }
 
     public function testSetPrivilegeNoParams(): void
@@ -508,7 +561,7 @@ final class PageTest extends TestCase
         ]);
 
         $page->setPrivilege();
-        $this->assertEquals(null, $page->getPrivilege());
+        $this->assertNull($page->getPrivilege());
     }
 
     public function testSetPrivilegeNull(): void
@@ -520,7 +573,7 @@ final class PageTest extends TestCase
         ]);
 
         $page->setPrivilege(null);
-        $this->assertEquals(null, $page->getPrivilege());
+        $this->assertNull($page->getPrivilege());
     }
 
     public function testSetPrivilegeString(): void
@@ -771,13 +824,18 @@ final class PageTest extends TestCase
         ]);
 
         $this->assertTrue(isset($page->uri));
+    }
 
-        try {
-            unset($page->uri);
-            $this->fail('Should not be possible to unset native properties');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Unsetting native property', $e->getMessage());
-        }
+    public function testUnsetNativePropertyShouldThrowException(): void
+    {
+        $page = AbstractPage::factory([
+            'label' => 'foo',
+            'uri'   => 'foo',
+        ]);
+
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsetting native property');
+        unset($page->uri);
     }
 
     public function testMagicOverLoadsShouldHandleCustomProperties(): void
@@ -962,13 +1020,9 @@ final class PageTest extends TestCase
     {
         $page = AbstractPage::factory(['type' => 'uri']);
 
-        try {
-            $page->setRel('alternate');
-            $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $relations', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $relations');
+        $page->setRel('alternate');
     }
 
     public function testSetRevShouldWorkWithArray(): void
@@ -1020,13 +1074,9 @@ final class PageTest extends TestCase
     {
         $page = AbstractPage::factory(['type' => 'uri']);
 
-        try {
-            $page->setRev('alternate');
-            $this->fail('An invalid value was set, but a '
-                        . 'Laminas\Navigation\Exception\InvalidArgumentException was not thrown');
-        } catch (Navigation\Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid argument: $relations', $e->getMessage());
-        }
+        $this->expectException(Navigation\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument: $relations');
+        $page->setRev('alternate');
     }
 
     public function testGetRelWithArgumentShouldRetrieveSpecificRelation(): void

--- a/test/Service/AbstractNavigationFactoryTest.php
+++ b/test/Service/AbstractNavigationFactoryTest.php
@@ -13,13 +13,6 @@ use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
-use function sprintf;
-
-/**
- * @todo Write tests covering full functionality. Tests were introduced to
- *     resolve zendframework/zend-navigation#37, and cover one specific
- *     method to ensure argument validation works correctly.
- */
 final class AbstractNavigationFactoryTest extends TestCase
 {
     private TestAsset\TestNavigationFactory $factory;
@@ -35,16 +28,8 @@ final class AbstractNavigationFactoryTest extends TestCase
         $router     = $this->createMock(Router\RouteStackInterface::class);
         $args       = [[], $routeMatch, $router];
 
-        $r = new ReflectionMethod($this->factory, 'injectComponents');
-        try {
-            $pages = $r->invokeArgs($this->factory, $args);
-        } catch (Exception\InvalidArgumentException $e) {
-            $message = sprintf(
-                'injectComponents should not raise exception for laminas-router classes; received %s',
-                $e->getMessage()
-            );
-            $this->fail($message);
-        }
+        $r     = new ReflectionMethod($this->factory, 'injectComponents');
+        $pages = $r->invokeArgs($this->factory, $args);
 
         $this->assertSame([], $pages);
     }
@@ -74,5 +59,83 @@ final class AbstractNavigationFactoryTest extends TestCase
         $navigation        = $navigationFactory->createService($serviceManagerMock);
 
         $this->assertInstanceOf(Navigation::class, $navigation);
+    }
+
+    public function testThrowsExceptionWhenNavigationConfigKeyMissing(): void
+    {
+        $serviceManagerMock = $this->createMock(ServiceManager::class);
+        $serviceManagerMock->expects($this->any())
+            ->method('get')
+            ->with('config')
+            ->willReturn([]);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find navigation configuration key');
+
+        $this->factory->createService($serviceManagerMock);
+    }
+
+    public function testThrowsExceptionWhenNavigationContainerNotFound(): void
+    {
+        $serviceManagerMock = $this->createMock(ServiceManager::class);
+        $serviceManagerMock->expects($this->any())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['navigation' => []]);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Failed to find a navigation container by the name "test"');
+
+        $this->factory->createService($serviceManagerMock);
+    }
+
+    public function testInjectComponentsThrowsExceptionForInvalidRouteMatch(): void
+    {
+        $r = new ReflectionMethod($this->factory, 'injectComponents');
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Laminas\Router\RouteMatch expected');
+
+        $r->invokeArgs($this->factory, [[], 'invalid-route-match', null]);
+    }
+
+    public function testInjectComponentsThrowsExceptionForInvalidRouter(): void
+    {
+        $r = new ReflectionMethod($this->factory, 'injectComponents');
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Laminas\Router\RouteMatch expected');
+
+        $r->invokeArgs($this->factory, [[], null, 'invalid-router']);
+    }
+
+    public function testGetPagesFromConfigThrowsExceptionForNonExistentFile(): void
+    {
+        $r = new ReflectionMethod($this->factory, 'getPagesFromConfig');
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        $r->invokeArgs($this->factory, ['/non/existent/file.php']);
+    }
+
+    public function testGetPagesFromConfigThrowsExceptionForInvalidType(): void
+    {
+        $r = new ReflectionMethod($this->factory, 'getPagesFromConfig');
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid input, expected array, filename, or Traversable object');
+
+        $r->invokeArgs($this->factory, [12345]);
+    }
+
+    public function testInjectComponentsWithNullRouter(): void
+    {
+        $routeMatch = $this->createMock(Router\RouteMatch::class);
+        $r          = new ReflectionMethod($this->factory, 'injectComponents');
+
+        $pages = $r->invokeArgs($this->factory, [[], $routeMatch, null]);
+
+        $this->assertSame([], $pages);
     }
 }

--- a/test/Service/AbstractNavigationFactoryTest.php
+++ b/test/Service/AbstractNavigationFactoryTest.php
@@ -41,53 +41,41 @@ final class AbstractNavigationFactoryTest extends TestCase
         /** @psalm-suppress InvalidArgument */
         $mvcEventStub->setRouter(new Router\Http\TreeRouteStack());
 
-        $applicationMock = $this->createMock(Application::class);
+        $applicationStub = $this->createStub(Application::class);
+        $applicationStub->method('getMvcEvent')->willReturn($mvcEventStub);
 
-        $applicationMock->expects($this->any())
-            ->method('getMvcEvent')
-            ->willReturn($mvcEventStub);
-
-        $serviceManagerMock = $this->createMock(ServiceManager::class);
-
-        $serviceManagerMock->expects($this->any())
-            ->method('get')
-            ->willReturnMap([
-                ['config', ['navigation' => ['testStubNavigation' => []]]],
-                ['Application', $applicationMock],
-            ]);
+        $serviceManagerStub = $this->createStub(ServiceManager::class);
+        $serviceManagerStub->method('get')->willReturnMap([
+            ['config', ['navigation' => ['testStubNavigation' => []]]],
+            ['Application', $applicationStub],
+        ]);
 
         $navigationFactory = new TestAsset\TestNavigationFactory('testStubNavigation');
-        $navigation        = $navigationFactory->createService($serviceManagerMock);
+        $navigation        = $navigationFactory->createService($serviceManagerStub);
 
         $this->assertInstanceOf(Navigation::class, $navigation);
     }
 
     public function testThrowsExceptionWhenNavigationConfigKeyMissing(): void
     {
-        $serviceManagerMock = $this->createMock(ServiceManager::class);
-        $serviceManagerMock->expects($this->any())
-            ->method('get')
-            ->with('config')
-            ->willReturn([]);
+        $serviceManagerStub = $this->createStub(ServiceManager::class);
+        $serviceManagerStub->method('get')->willReturn([]);
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not find navigation configuration key');
 
-        $this->factory->createService($serviceManagerMock);
+        $this->factory->createService($serviceManagerStub);
     }
 
     public function testThrowsExceptionWhenNavigationContainerNotFound(): void
     {
-        $serviceManagerMock = $this->createMock(ServiceManager::class);
-        $serviceManagerMock->expects($this->any())
-            ->method('get')
-            ->with('config')
-            ->willReturn(['navigation' => []]);
+        $serviceManagerStub = $this->createStub(ServiceManager::class);
+        $serviceManagerStub->method('get')->willReturn(['navigation' => []]);
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Failed to find a navigation container by the name "test"');
 
-        $this->factory->createService($serviceManagerMock);
+        $this->factory->createService($serviceManagerStub);
     }
 
     public function testInjectComponentsThrowsExceptionForInvalidRouteMatch(): void

--- a/test/ServiceFactoryTest.php
+++ b/test/ServiceFactoryTest.php
@@ -66,8 +66,8 @@ final class ServiceFactoryTest extends TestCase
         $this->serviceManager = $serviceManager = new ServiceManager();
         $serviceManager->setService('config', $config);
 
-        $router  = $this->createMock(RouteStackInterface::class);
-        $request = $this->createMock(HttpRequest::class);
+        $router  = $this->createStub(RouteStackInterface::class);
+        $request = $this->createStub(HttpRequest::class);
 
         $routeMatch = new RouteMatch([
             'controller' => 'post',
@@ -75,13 +75,13 @@ final class ServiceFactoryTest extends TestCase
             'id'         => '1337',
         ]);
 
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $mvcEvent->expects(self::any())->method('getRouteMatch')->willReturn($routeMatch);
-        $mvcEvent->expects(self::any())->method('getRouter')->willReturn($router);
-        $mvcEvent->expects(self::any())->method('getRequest')->willReturn($request);
+        $mvcEvent = $this->createStub(MvcEvent::class);
+        $mvcEvent->method('getRouteMatch')->willReturn($routeMatch);
+        $mvcEvent->method('getRouter')->willReturn($router);
+        $mvcEvent->method('getRequest')->willReturn($request);
 
-        $application = $this->createMock(Application::class);
-        $application->expects(self::any())->method('getMvcEvent')->willReturn($mvcEvent);
+        $application = $this->createStub(Application::class);
+        $application->method('getMvcEvent')->willReturn($mvcEvent);
 
         $serviceManager->setService('Application', $application);
         $serviceManager->setAllowOverride(true);
@@ -123,7 +123,7 @@ final class ServiceFactoryTest extends TestCase
 
         $factory = $builder->getMock();
 
-        $factory->expects($this->once())
+        $factory->expects(self::once())
                 ->method('injectComponents')
                 ->with(
                     new IsType('array'),

--- a/test/ServiceFactoryTest.php
+++ b/test/ServiceFactoryTest.php
@@ -366,8 +366,8 @@ final class ServiceFactoryTest extends TestCase
 
     public function testNavigationAbstractServiceFactoryInvokesWithExactCaseConfigName(): void
     {
-        $router  = $this->createMock(RouteStackInterface::class);
-        $request = $this->createMock(HttpRequest::class);
+        $router  = $this->createStub(RouteStackInterface::class);
+        $request = $this->createStub(HttpRequest::class);
 
         $routeMatch = new RouteMatch([
             'controller' => 'post',
@@ -375,10 +375,10 @@ final class ServiceFactoryTest extends TestCase
             'id'         => '1337',
         ]);
 
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $mvcEvent->expects(self::any())->method('getRouteMatch')->willReturn($routeMatch);
-        $mvcEvent->expects(self::any())->method('getRouter')->willReturn($router);
-        $mvcEvent->expects(self::any())->method('getRequest')->willReturn($request);
+        $mvcEvent = $this->createStub(MvcEvent::class);
+        $mvcEvent->method('getRouteMatch')->willReturn($routeMatch);
+        $mvcEvent->method('getRouter')->willReturn($router);
+        $mvcEvent->method('getRequest')->willReturn($request);
 
         $application = $this->createMock(Application::class);
         $application->expects(self::any())->method('getMvcEvent')->willReturn($mvcEvent);

--- a/test/ServiceFactoryTest.php
+++ b/test/ServiceFactoryTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use ReflectionMethod;
 
 #[CoversClass(AbstractNavigationFactory::class)]
 #[CoversClass(DefaultNavigationFactory::class)]
@@ -113,8 +114,6 @@ final class ServiceFactoryTest extends TestCase
 
     public function testConstructedNavigationFactoryInjectRouterAndMatcher(): void
     {
-        self::markTestSkipped('ConstructedNavigationFactory is now final and cannot be mocked');
-
         $builder = $this->getMockBuilder(ConstructedNavigationFactory::class);
         $builder->setConstructorArgs([__DIR__ . '/_files/navigation_mvc.xml'])
                 ->onlyMethods(['injectComponents']);
@@ -248,5 +247,164 @@ final class ServiceFactoryTest extends TestCase
 
         $this->assertInstanceOf(Navigation::class, $container);
         $this->assertEquals(3, $container->count());
+    }
+
+    public function testNavigationAbstractServiceFactoryV2CanCreateServiceWithName(): void
+    {
+        $factory = new NavigationAbstractServiceFactory();
+
+        $this->assertTrue(
+            $factory->canCreateServiceWithName($this->serviceManager, 'name', 'Laminas\Navigation\File')
+        );
+        $this->assertFalse(
+            $factory->canCreateServiceWithName($this->serviceManager, 'name', 'Laminas\Navigation\Unknown')
+        );
+    }
+
+    public function testNavigationAbstractServiceFactoryV2CreateServiceWithName(): void
+    {
+        $factory = new NavigationAbstractServiceFactory();
+
+        $container = $factory->createServiceWithName(
+            $this->serviceManager,
+            'name',
+            'Laminas\Navigation\File'
+        );
+
+        $this->assertInstanceOf(Navigation::class, $container);
+        $this->assertEquals(3, $container->count());
+    }
+
+    public function testNavigationAbstractServiceFactoryReturnsFalseWhenNoConfigService(): void
+    {
+        $services = new ServiceManager();
+        $factory  = new NavigationAbstractServiceFactory();
+
+        $this->assertFalse($factory->canCreate($services, 'Laminas\Navigation\Test'));
+    }
+
+    public function testNavigationAbstractServiceFactoryReturnsFalseWhenNoNavigationConfig(): void
+    {
+        $services = new ServiceManager([
+            'services' => [
+                'config' => [],
+            ],
+        ]);
+        $factory  = new NavigationAbstractServiceFactory();
+
+        $this->assertFalse($factory->canCreate($services, 'Laminas\Navigation\Test'));
+    }
+
+    public function testNavigationAbstractServiceFactorySupportsLowercaseConfigName(): void
+    {
+        $services = new ServiceManager([
+            'services' => [
+                'config' => [
+                    'navigation' => [
+                        'lowercase' => [
+                            ['label' => 'Test', 'uri' => '#'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $factory  = new NavigationAbstractServiceFactory();
+
+        $this->assertTrue($factory->canCreate($services, 'Laminas\Navigation\Lowercase'));
+    }
+
+    public function testConstructedNavigationFactoryGetName(): void
+    {
+        $factory = new ConstructedNavigationFactory([]);
+
+        $this->assertSame('constructed', $factory->getName());
+    }
+
+    public function testNavigationAbstractServiceFactoryReturnsFalseForNonNavigationPrefix(): void
+    {
+        $services = new ServiceManager([
+            'services' => [
+                'config' => [
+                    'navigation' => [
+                        'test' => [],
+                    ],
+                ],
+            ],
+        ]);
+        $factory  = new NavigationAbstractServiceFactory();
+
+        $this->assertFalse($factory->canCreate($services, 'SomeOther\Service'));
+    }
+
+    public function testNavigationAbstractServiceFactoryWithExactCaseConfigName(): void
+    {
+        $services = new ServiceManager([
+            'services' => [
+                'config' => [
+                    'navigation' => [
+                        'ExactCase' => [
+                            ['label' => 'Test', 'uri' => '#'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $factory  = new NavigationAbstractServiceFactory();
+
+        $this->assertTrue($factory->canCreate($services, 'Laminas\Navigation\ExactCase'));
+    }
+
+    public function testNavigationAbstractServiceFactoryInvokesWithExactCaseConfigName(): void
+    {
+        $router  = $this->createMock(RouteStackInterface::class);
+        $request = $this->createMock(HttpRequest::class);
+
+        $routeMatch = new RouteMatch([
+            'controller' => 'post',
+            'action'     => 'view',
+            'id'         => '1337',
+        ]);
+
+        $mvcEvent = $this->createMock(MvcEvent::class);
+        $mvcEvent->expects(self::any())->method('getRouteMatch')->willReturn($routeMatch);
+        $mvcEvent->expects(self::any())->method('getRouter')->willReturn($router);
+        $mvcEvent->expects(self::any())->method('getRequest')->willReturn($request);
+
+        $application = $this->createMock(Application::class);
+        $application->expects(self::any())->method('getMvcEvent')->willReturn($mvcEvent);
+
+        $services = new ServiceManager([
+            'services' => [
+                'config'      => [
+                    'navigation' => [
+                        'ExactCase' => [
+                            ['label' => 'Test', 'uri' => '#'],
+                        ],
+                    ],
+                ],
+                'Application' => $application,
+            ],
+        ]);
+        $factory  = new NavigationAbstractServiceFactory();
+
+        $container = $factory($services, 'Laminas\Navigation\ExactCase');
+
+        $this->assertInstanceOf(Navigation::class, $container);
+        $this->assertEquals(1, $container->count());
+    }
+
+    public function testGetNamedConfigReturnsEmptyArrayWhenNoMatchingConfig(): void
+    {
+        $factory = new NavigationAbstractServiceFactory();
+
+        $r = new ReflectionMethod($factory, 'getNamedConfig');
+
+        $config = [
+            'other' => [['label' => 'Test', 'uri' => '#']],
+        ];
+
+        $result = $r->invoke($factory, 'Laminas\Navigation\NonExistent', $config);
+
+        $this->assertSame([], $result);
     }
 }

--- a/test/View/HelperConfigTest.php
+++ b/test/View/HelperConfigTest.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace LaminasTest\Navigation\View;
 
+use ArrayObject;
 use Laminas\Navigation\Service\DefaultNavigationFactory;
 use Laminas\Navigation\View\HelperConfig;
+use Laminas\Navigation\View\NavigationHelperFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Helper\Navigation as NavigationHelper;
 use Laminas\View\HelperPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
 
 /**
  * Tests the class Laminas_Navigation_Page_Mvc
@@ -80,5 +84,120 @@ final class HelperConfigTest extends TestCase
 
         $menu = $helpers->get($navigationHelperServiceName)->findHelper('menu');
         $this->assertInstanceOf($replacedMenuClass, $menu);
+    }
+
+    public function testConfigureServiceManagerWithoutConfigService(): void
+    {
+        $serviceManager = new ServiceManager();
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        (new HelperConfig())->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has('navigation'));
+        $this->assertTrue($helpers->has(NavigationHelper::class));
+    }
+
+    public function testConstructorMergesInvokablesConfig(): void
+    {
+        $config = new HelperConfig([
+            'invokables' => [
+                'testHelper' => NavigationHelper\Menu::class,
+            ],
+        ]);
+
+        $serviceManager = new ServiceManager();
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        $config->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has('testHelper'));
+    }
+
+    public function testConfigureServiceManagerWithNoNavigationHelpersConfig(): void
+    {
+        $serviceManager = new ServiceManager([
+            'services' => [
+                'config' => [
+                    'other_key' => [],
+                ],
+            ],
+        ]);
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        (new HelperConfig())->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has('navigation'));
+    }
+
+    public function testConfigureServiceManagerTwiceUsesCachedDelegator(): void
+    {
+        $serviceManager = new ServiceManager();
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        $config = new HelperConfig();
+
+        $config->configureServiceManager($helpers);
+        $config->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has('navigation'));
+    }
+
+    public function testConstructorWithInvokableWhereNameEqualsClass(): void
+    {
+        $config = new HelperConfig([
+            'invokables' => [
+                NavigationHelper\Menu::class => NavigationHelper\Menu::class,
+            ],
+        ]);
+
+        $serviceManager = new ServiceManager();
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        $config->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has(NavigationHelper\Menu::class));
+    }
+
+    public function testConfigureServiceManagerWithTraversableConfig(): void
+    {
+        $traversableConfig = new ArrayObject([
+            'navigation_helpers' => [
+                'aliases' => [
+                    'customNav' => NavigationHelper::class,
+                ],
+            ],
+        ]);
+
+        $serviceManager = new ServiceManager([
+            'services' => [
+                'config' => $traversableConfig,
+            ],
+        ]);
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        (new HelperConfig())->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has('customNav'));
+    }
+
+    public function testInjectNavigationDelegatorFactorySkipsWhenAlreadyPresent(): void
+    {
+        $config = new HelperConfig();
+
+        $prepareMethod = new ReflectionMethod($config, 'prepareNavigationDelegatorFactory');
+        $factory       = $prepareMethod->invoke($config);
+
+        $configProperty = new ReflectionProperty($config, 'config');
+        $internalConfig = $configProperty->getValue($config);
+
+        $internalConfig['delegators'][NavigationHelperFactory::class][] = $factory;
+        $configProperty->setValue($config, $internalConfig);
+
+        $serviceManager = new ServiceManager();
+        $helpers        = new HelperPluginManager($serviceManager);
+
+        $config->configureServiceManager($helpers);
+
+        $this->assertTrue($helpers->has('navigation'));
     }
 }

--- a/test/View/NavigationHelperFactoryTest.php
+++ b/test/View/NavigationHelperFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Navigation\View;
+
+use Laminas\Navigation\View\NavigationHelperFactory;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\View\Helper\Navigation as NavigationHelper;
+use Laminas\View\HelperPluginManager;
+use PHPUnit\Framework\TestCase;
+
+final class NavigationHelperFactoryTest extends TestCase
+{
+    public function testInvokeReturnsNavigationHelper(): void
+    {
+        $services = new ServiceManager();
+        $helpers  = new HelperPluginManager($services);
+
+        $factory = new NavigationHelperFactory();
+        $result  = $factory($helpers, NavigationHelper::class);
+
+        $this->assertInstanceOf(NavigationHelper::class, $result);
+    }
+
+    public function testCreateServiceV2ReturnsNavigationHelper(): void
+    {
+        $services = new ServiceManager();
+        $helpers  = new HelperPluginManager($services);
+
+        $factory = new NavigationHelperFactory();
+        $result  = $factory->createService($helpers);
+
+        $this->assertInstanceOf(NavigationHelper::class, $result);
+    }
+}

--- a/test/View/ViewHelperManagerDelegatorFactoryTest.php
+++ b/test/View/ViewHelperManagerDelegatorFactoryTest.php
@@ -24,4 +24,17 @@ final class ViewHelperManagerDelegatorFactoryTest extends TestCase
         $this->assertTrue($helpers->has('navigation'));
         $this->assertTrue($helpers->has(NavigationHelper::class));
     }
+
+    public function testCreateDelegatorWithNameV2(): void
+    {
+        $services = new ServiceManager();
+        $helpers  = new HelperPluginManager($services);
+        $callback = fn(): HelperPluginManager => $helpers;
+
+        $factory = new ViewHelperManagerDelegatorFactory();
+        $result  = $factory->createDelegatorWithName($services, 'name', 'ViewHelperManager', $callback);
+
+        $this->assertSame($helpers, $result);
+        $this->assertTrue($helpers->has('navigation'));
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Modernize test suite and remove dead v2 code

This cleans up the test suite to use more concise PHPUnit patterns and removes some code that can no longer be   executed.

Now has 100% code coverage in PHPUnit.

Test changes:
- Replaced try/catch exception testing with expectException()
- Added data providers where we had repetitive test cases
- Switched to more direct assertions (assertTrue/assertFalse instead of assertSame(true, ...))
- Enabled a test that was incorrectly marked as skipped - ConstructedNavigationFactory isn't actually final and
can be mocked without issue
- Added some additional test coverage for the v2 factory methods while they're still technically able to be executed

Dead code removal:
- Removed the v2 ServiceLocator code path in HelperConfig::getParentContainer(). This branch checked for the
absence of a configure() method to detect SM v2, but since laminas-navigation now requires PHP 8.2+ and
ServiceManager v2 only supports PHP 5.5-7.x, this code path was impossible to reach.